### PR TITLE
add task to show routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-promise": "^5.1.0",
+        "express-list-routes": "^1.1.3",
         "husky": "^7.0.4",
         "nodemon": "^2.0.15",
         "prettier": "^2.6.2",
@@ -1585,6 +1586,12 @@
       "engines": {
         "node": ">= 0.10.0"
       }
+    },
+    "node_modules/express-list-routes": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/express-list-routes/-/express-list-routes-1.1.3.tgz",
+      "integrity": "sha512-M5ssbdYsspn4UPErwQ0qotaqK4uHOpN8WeHeSWQ0wmw0I+vyqbTNaCVEN7x+oFINowYisbQZ04Q/OQ5FU6dTOQ==",
+      "dev": true
     },
     "node_modules/express/node_modules/debug": {
       "version": "2.6.9",
@@ -5424,6 +5431,12 @@
           "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
         }
       }
+    },
+    "express-list-routes": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/express-list-routes/-/express-list-routes-1.1.3.tgz",
+      "integrity": "sha512-M5ssbdYsspn4UPErwQ0qotaqK4uHOpN8WeHeSWQ0wmw0I+vyqbTNaCVEN7x+oFINowYisbQZ04Q/OQ5FU6dTOQ==",
+      "dev": true
     },
     "fast-deep-equal": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "start": "node src/index.js",
     "dev": "nodemon src/index.js",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "routes": "node src/tasks/show-routes.js"
   },
   "repository": {
     "type": "git",
@@ -32,7 +33,8 @@
     "husky": "^7.0.4",
     "nodemon": "^2.0.15",
     "prettier": "^2.6.2",
-    "prisma": "^3.12.0"
+    "prisma": "^3.12.0",
+    "express-list-routes": "^1.1.3"
   },
   "dependencies": {
     "@prisma/client": "^3.12.0",

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,39 @@
+import 'dotenv/config'
+import express from 'express'
+import cors from 'cors'
+import userRouter from './routes/user.js'
+import postRouter from './routes/post.js'
+import authRouter from './routes/auth.js'
+import cohortRouter from './routes/cohort.js'
+import noteRouter from './routes/note.js'
+import exerciseRouter from './routes/exercise.js'
+import courseRouter from './routes/course.js'
+import deliveryLogRouter from './routes/deliveryLog.js'
+
+const app = express()
+app.disable('x-powered-by')
+app.use(cors())
+app.use(express.json())
+app.use(express.urlencoded({ extended: true }))
+
+app.use('/user', userRouter)
+app.use('/users', userRouter)
+app.use('/post', postRouter)
+app.use('/posts', postRouter)
+app.use('/cohort', cohortRouter)
+app.use('/log', deliveryLogRouter)
+app.use('/note', noteRouter)
+app.use('/', authRouter)
+app.use('/exercises', exerciseRouter)
+app.use('/courses', courseRouter)
+
+app.get('*', (req, res) => {
+  res.status(404).json({
+    status: 'fail',
+    data: {
+      resource: 'Not found'
+    }
+  })
+})
+
+export default app

--- a/src/index.js
+++ b/src/index.js
@@ -1,40 +1,4 @@
-import 'dotenv/config'
-import express from 'express'
-import cors from 'cors'
-import userRouter from './routes/user.js'
-import postRouter from './routes/post.js'
-import authRouter from './routes/auth.js'
-import cohortRouter from './routes/cohort.js'
-import noteRouter from './routes/note.js'
-import exerciseRouter from './routes/exercise.js'
-import courseRouter from './routes/course.js'
-import deliveryLogRouter from './routes/deliveryLog.js'
-
-const app = express()
-app.disable('x-powered-by')
-app.use(cors())
-app.use(express.json())
-app.use(express.urlencoded({ extended: true }))
-
-app.use('/user', userRouter)
-app.use('/users', userRouter)
-app.use('/post', postRouter)
-app.use('/posts', postRouter)
-app.use('/cohort', cohortRouter)
-app.use('/log', deliveryLogRouter)
-app.use('/note', noteRouter)
-app.use('/', authRouter)
-app.use('/exercises', exerciseRouter)
-app.use('/courses', courseRouter)
-
-app.get('*', (req, res) => {
-  res.status(404).json({
-    status: 'fail',
-    data: {
-      resource: 'Not found'
-    }
-  })
-})
+import app from './app.js'
 
 const port = process.env.PORT || 4000
 

--- a/src/tasks/show-routes.js
+++ b/src/tasks/show-routes.js
@@ -1,0 +1,5 @@
+import expressListRoutes from 'express-list-routes'
+
+import app from '../app.js'
+
+expressListRoutes(app)


### PR DESCRIPTION
Use `npm run routes` to display all available routes for the application
 
Change
- extracted app from runner (app is now in app.js, runner is now index.js)
- Running the app using `npm` scripts is still supported
- added 1 dependency: https://www.npmjs.com/package/express-list-routes

![Screenshot 2022-07-13 at 11 57 02](https://user-images.githubusercontent.com/13719921/178717963-435fa140-97f6-4ec8-ace7-2cf5819cbd36.png)